### PR TITLE
docs(pt): ajustment on a text inside `template-syntax.md`

### DIFF
--- a/src/guide/essentials/template-syntax.md
+++ b/src/guide/essentials/template-syntax.md
@@ -148,7 +148,7 @@ Nos modelos de marcação da Vue, as expressões de JavaScript podem ser usadas 
 
 ### Somente Expressões {#expressions-only}
 
-Cada vínculo apenas pode conter **uma única expressão**. Uma expressão é um pedaço de código que pode ser avaliada para um valor. Um verificação simples é se pode ser usada depois de `return`.
+Cada vínculo apenas pode conter **uma única expressão**. Uma expressão é um pedaço de código que pode ser avaliada para um valor. Uma verificação simples é se pode ser usada depois de `return`.
 
 Portanto, as seguintes **não** funcionarão:
 


### PR DESCRIPTION
## Description of Problem
The problem was that it has been written:

Somente Expressões​
Cada vínculo apenas pode conter uma única expressão. Uma expressão é um pedaço de código que pode ser avaliada para um valor. (Um verificação -> ERRO) simples é se pode ser usada depois de return.

## Proposed Solution

The proposed solution was to correct from 'Um verificação' to "Uma verificação".

## Additional Information

"'Verification' is a feminine noun, and when using it in a sentence, the feminine definite article 'a' should be used before the word. Therefore, the correct sentence would be: 'Why should we write a verification?'"
